### PR TITLE
fix upload results, fix how images now are shown

### DIFF
--- a/public/api/resources/controllers/admissionsBlueprint.php
+++ b/public/api/resources/controllers/admissionsBlueprint.php
@@ -1,0 +1,29 @@
+<?php
+
+  include_once __DIR__ . '/../../../../services/resources/services/Resources.php';
+  include_once __DIR__ . '/../../../../utils/classes/Request.php';
+
+  session_start();
+
+  Request::isWrongRequestMethod('GET');
+
+  if (empty($_SESSION) || !in_array("ADMINISTRATOR" ,$_SESSION['ROLES'])) {
+    http_response_code(403);
+    echo json_encode([
+      "status" => "failure",
+      "error" => [
+        "errorCode" => 403,
+        "errorMessage" => "Forbidden"
+      ]
+    ]);
+    return;
+  }
+
+  header("Content-Type: text/csv");
+  header("Content-Disposition: attachment; filename=admissionsBlueprint.csv");
+  header("Expires: 0");
+
+  Resources::downloadUploadAdmissionExamResultsFormat();
+  http_response_code(200);
+
+

--- a/public/views/admissions/applicantResults/index.php
+++ b/public/views/admissions/applicantResults/index.php
@@ -31,6 +31,8 @@
     <d-table id="tb" body-id="table-body-results" table-row='["Examen", "Fecha", "Calificación", "Numero de Solicitud"]'></d-table>
   </d-modal>
 
+  <loading-modal loading-id="loading" modal-id="loading-modal"></loading-modal>
+
 <!-- pop up to show errors -->
   <pop-up
     id="popUp"
@@ -68,6 +70,7 @@
   <script src="../../js/components/pop-up.js"></script>
   <script src="../../js/components/footer.js"></script>
   <script src="../../js/components/table.js"></script>
+  <script src="../../js/components/loading.js"></script>
   <script type="module" src="../../js/resultados.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"

--- a/public/views/admissions/uploadExamResults/controllers/downloadBlueprint.js
+++ b/public/views/admissions/uploadExamResults/controllers/downloadBlueprint.js
@@ -1,0 +1,32 @@
+import { Request } from "../../../js/modules/request.mjs"
+import { downloadFile, hideLoadingComponent, showFailModal, showLoadingComponent } from "../../../js/modules/utlis.mjs"
+
+const downloadBtn = document.getElementById('admission-blueprint')
+
+downloadBtn.addEventListener('click', (event) => {
+  event.preventDefault()
+  downloadBtn.disable = true
+  downloadBtn.classList.remove('hover')
+  downloadBtn.style.backgroundColor = '#8A94A6'
+  showLoadingComponent('loading')
+  downloadBlueprint()
+  hideLoadingComponent('loading')
+  setTimeout(() => {
+    downloadBtn.disable = false
+    downloadBtn.classList.add('hover')
+    downloadBtn.style.backgroundColor = '#000E33'
+  }, 1300)
+})
+
+
+async function downloadBlueprint() {
+  const URL = '/api/resources/controllers/admissionsBlueprint.php'
+  try {
+    const res = await fetch(URL) 
+    const blob = await res.blob()
+    downloadFile('blueprint', blob) 
+  } catch(err) {
+    console.log(err)
+    showFailModal('csv-upload', "No se pudo descargar el archivo... Intente más tarde")
+  }
+}

--- a/public/views/admissions/uploadExamResults/index.php
+++ b/public/views/admissions/uploadExamResults/index.php
@@ -25,23 +25,28 @@
   <div class="container bg-white">
     <user-profile
     profile-title="Subir Resultados Admisión"
-    profile-img="<?php echo $_SESSION['PHOTO'] ?>"
+    profile-img="<?php echo base64_encode($_SESSION['PHOTO']) ?>"
     welcome-msg="Bienvenido a Sistema Admisión"
-    user-number="123456"
+    user-number="<?php echo $_SESSION['DNI'] ?>"
     user-name="<?php echo $_SESSION['FIRST_NAME'] . $_SESSION['LAST_NAME'] ?>"
     user-phone="<?php echo $_SESSION['PHONE'] ?>"
     user-email="<?php echo $_SESSION['INST_EMAIL'] ?>"
     >
     </user-profile>
-    <div class="upload-wrapper mb-3">
+    <div class="upload-wrapper mb-3 d-flex justify-content-center align-items-center">
+      <div class="me-2">
         <label for="csvFile" class="upload-btn">Subir Resultados</label>
         <input type="file" id="csvFile" name="csvFile" accept=".csv">
+      </div>
+      <div>
+        <button class="download-btn" id="admission-blueprint">Descargar formato</button>
+      </div>
     </div>
   </div>
 
   <loading-modal tag-id="loading" modal-id="loading-modal"></loading-modal>
 
-  <modal-error tag-id="csv-upload" modal-id="file-upload" arial-label-led-by="fileErrorModal" header-title="No se pudo procesar el archivo" arial-label="TEXT" hidden="false"></modal-error>
+  <modal-error tag-id="csv-upload" modal-id="file-upload" arial-label-led-by="fileErrorModal" header-title="" arial-label="TEXT" hidden="false"></modal-error>
 
   <modal-success tag-id="csv-upload-s" modal-id="file-upload-s" arial-label-led-by="fileSuccessModal" header-title="Archivo subido Correctamente" arial-label="sucess" hidden="false"></modal-success>
   <reviewer-modal tag-id="reviewer" application="../../loginRevisorSolicitudesAd.php" exam="./login.php"></reviewer-modal>
@@ -60,5 +65,6 @@
   <script src="../../js/components/successModal.js"></script>
   <script src="../../js/components/pop-up.js"></script>
   <script type="module" src="./controllers/parseCsv.js"></script>
+  <script type="module" src="./controllers/downloadBlueprint.js"></script>
 </body>
 </html>

--- a/public/views/css/revisorExamenesStyles.css
+++ b/public/views/css/revisorExamenesStyles.css
@@ -26,6 +26,51 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
+.download-btn {
+  position: relative;
+  display: inline-block;
+  font-family: "Helvetica Neue", sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+  color: var(--white);
+  background: var(--secondary-color);
+  padding: 15px 40px;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.download-btn::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.3);
+  transform: skewX(-25deg);
+  transition: transform 0.5s ease;
+}
+
+.download-btn:hover::after {
+  transform: skewX(-25deg) translateX(200%);
+}
+
+.download-btn:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+}
+
+.download-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+
+
 .upload-btn::after {
   content: "";
   position: absolute;

--- a/public/views/js/components/failModal.js
+++ b/public/views/js/components/failModal.js
@@ -6,8 +6,10 @@ class failModal extends HTMLElement {
     this.ariaLabelLedBy = ''
     this.arialLabel = ''
     this.hidden = "true"
-    this.headerTitle = ''
   }
+
+  static observedAttributes = ['header-title']
+
 
   connectedCallback(){
     this.modalErrorID = this.getAttribute('tag-id')

--- a/public/views/js/components/userProfile.js
+++ b/public/views/js/components/userProfile.js
@@ -35,7 +35,7 @@ class UserProfile extends HTMLElement {
                       </div>
                       <div class="d-flex flex-row justify-content-between align-items-center profile-container-body-info">
                         <div class="profile-container-body-info-img">
-                          <img src=${ this.profileImg } alt=${ this.imgDescription ?? 'Foto perfil del usuario' }>
+                          <img src=${"data:image/png;base64," + this.profileImg } alt=${ this.imgDescription ?? 'Foto perfil del usuario' }>
                         </div>
                         <div class="profile-container-body-info-personal">
                           <section>

--- a/public/views/js/modules/csv.mjs
+++ b/public/views/js/modules/csv.mjs
@@ -41,11 +41,11 @@ export class CSV {
           const csvText = fileReader.result
           if (!this.#isValidFormat(csvText, columns)) {
             hideLoadingComponent(loadingID)
-            showFailModal(errorModalID)
+            showFailModal(errorModalID, "Formato inválido de columnas")
           } else {
             if (!this.#isValidData(csvText)) {
               hideLoadingComponent(loadingID)
-              showFailModal(errorModalID)
+              showFailModal(errorModalID, 'Los datos no concuerdan con las columnas')
               return
             }
             
@@ -59,19 +59,19 @@ export class CSV {
               if (res.status == 'success') {
                 showSuccessModal(successModalID)
               } else {
-                showFailModal(errorModalID)
+                showFailModal(errorModalID, "No se pudo guardar en el servidor... Intente de nuevo")
               }
               
             } catch(err) {
               hideLoadingComponent(loadingID)
-              showFailModal(errorModalID)
+              showFailModal(errorModalID, "Error del servidor al guardar... Intente de nuevo")
             }
           }
 
         })
 
       } catch(err) {
-        showFailModal(errorModalID)
+        showFailModal(errorModalID, err.message)
       }
     })
   } 

--- a/public/views/js/modules/utlis.mjs
+++ b/public/views/js/modules/utlis.mjs
@@ -47,8 +47,9 @@ export function loginFailHandler(){
  * @param {string} modalErrorId 
  * this is the id of the custom element with tag-id
  */
-export function showFailModal(modalErrorId) {
+export function showFailModal(modalErrorId, message="Hubo un error...") {
     const modal = document.getElementById(modalErrorId)
+    modal.setAttribute('header-title', message)
     modal.show()
 }
 
@@ -194,4 +195,19 @@ export function cleanTableBody(table){
 }
 
 
-  
+/**
+ * 
+ * @param {string} fileName 
+ * this is how the file will be called when user downloads it
+ * @param {blob} blob 
+ * blob file
+ */ 
+export function downloadFile(fileName, blob) {
+    let downloadLink = document.createElement("a");
+    downloadLink.download = fileName;
+    downloadLink.href = window.URL.createObjectURL(blob);
+    downloadLink.style.display = "none";
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
+}

--- a/public/views/js/resultados.js
+++ b/public/views/js/resultados.js
@@ -1,5 +1,5 @@
 import { Request } from "./modules/request.mjs";
-import { disableBtn, showModal, changeBorder, showPopUp } from "./modules/utlis.mjs";
+import { disableBtn, showModal, changeBorder, showPopUp, showLoadingComponent, hideLoadingComponent } from "./modules/utlis.mjs";
 import { validApplicantCode } from "./modules/validator.mjs";
 
 // Función para cargar y mostrar resultados; se utiliza el arreglo filtrado (si existe)
@@ -39,9 +39,11 @@ function loadResults(filteredResults) {
       }
 
       try {
+        showLoadingComponent('loading')
         const ENDPOINT = "/api/auth/controllers/applicantAuth.php"
         const body = { applicantCode: searchValue.value.trim() }
         const examResults = await Request.fetch(ENDPOINT, 'POST', body);
+        hideLoadingComponent('loading')
         if (examResults.status === "failure") {
           showPopUp("No se encontraron Resultados")
           return;

--- a/services/contentManagement/CSVControl.php
+++ b/services/contentManagement/CSVControl.php
@@ -57,10 +57,18 @@
       $db = Database::getDatabaseInstace();
       $mysqli = $db->getConnection();
 
-      $query_save_on_load = "CALL SP_SAVE_CSV_IN_TEMP(?)";
+      $query_save_on_load = "LOAD DATA LOCAL INFILE '$filePath' 
+                            INTO TABLE TBL_TEMP
+                            FIELDS TERMINATED BY ',' 
+                            LINES TERMINATED BY '\n'
+                            IGNORE 1 LINES;
+                            ";
       $query_save_res = "CALL SP_SAVE_ADMISSION_EXAM_RESULT()";
       try {
-        $db->callStoredProcedure($query_save_on_load, "s", [$filePath], mysqli: $mysqli);
+        //MYSQLI_OPT_LOCAL_INFILE is the 8 value
+        $mysqli->options(8, true);
+        $mysqli->query($query_save_on_load);
+        //$db->callStoredProcedure($query_save_on_load, "s", [$filePath], mysqli: $mysqli);
       } catch (Throwable $err) {
         return new CSVProcessStatus("failure", new ErrorResponse(500, $err->getMessage() . "1"));
       }

--- a/services/resources/services/Resources.php
+++ b/services/resources/services/Resources.php
@@ -28,4 +28,19 @@
       $mysqli->close();
       return new GetResponse(status: 'success', data: $resourcesResult->fetch_all(1));
     }
+
+
+    public static function downloadUploadAdmissionExamResultsFormat(): void {
+      $filepath = __DIR__ . '/../../../uploads/files/admissionsBlueprint.csv';
+      if (!file_exists($filepath)) {
+        echo json_encode([
+          "status" => "failure",
+          "error" => [
+            "errorCode" => 404,
+            "errorMessage" => "Data Not Found",
+          ]
+        ]);
+      }
+      readfile($filepath);
+    }
   }

--- a/utils/classes/Logger.php
+++ b/utils/classes/Logger.php
@@ -2,6 +2,7 @@
 
   include_once __DIR__ . '/../../services/auth/types/loginRequest.php';
   include_once __DIR__ . '/../functions/jsonParse.php';
+  include_once __DIR__ . '/../../services/contentManagement/ContentManagement.php';
 
   class Logger {
     public static function loginAuth(string $role) {
@@ -41,13 +42,15 @@
         "error" => null
       ]);
 
+      $imageBlob = ContentManagement::getFileData($sessionData->user->PHOTO);
+
       $_SESSION['FIRST_NAME'] = $sessionData->user->FIRST_NAME; 
       $_SESSION['LAST_NAME'] = $sessionData->user->LAST_NAME; 
       $_SESSION['DNI'] = $sessionData->user->DNI; 
       $_SESSION['INST_EMAIL'] = $sessionData->user->INST_EMAIL; 
       $_SESSION['PERSONAL_EMAIL'] = $sessionData->user->PERSONAL_EMAIL; 
       $_SESSION['ROLES'] = $sessionData->roles; 
-      $_SESSION['PHOTO'] = $sessionData->user->PHOTO;
+      $_SESSION['PHOTO'] = $imageBlob;
       $_SESSION['PHONE'] = $sessionData->user->PHONE_NUMBER;
       $_SESSION['USER'] = $sessionData->user;
     }


### PR DESCRIPTION
# UPLOAD RESULTS TESTED

## Modificatations
- Images are now sent as blob. Use `base64_encode($_SESSION["PHOTO"])` 
- Exam results csv format can be downloaded 
- Modals now show more dynamics error messages

## How images now are used
![image](https://github.com/user-attachments/assets/0c0c0dbe-88e2-4650-a30d-eae433553cb5)
